### PR TITLE
Nissix plugin scope-packages on ast-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "scripts": {
     "test": "mocha --reporter spec test/run.js"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "esprima": "~1.2.2",
     "esprima-fb": "~14001.1.0-dev-harmony-fb",


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.891s



Output Log:
Migrating package "ast-types" in .


## Migration from non scope to @wix/scoped packages
> /tmp/a2e9308c7e056e3ebbfd4d3d9ba3823f

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

